### PR TITLE
Upcase `api'

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,7 +11,7 @@
           <div class='pl2 pl0-ns pv4' style='max-width:650px'>
             <p class='ma0 f4 lh-copy'>
               <strong>We're close.</strong> We need to fix issues in existing p2p features like webRTC
-          and rally support for new browser apis, to create a level playing field
+          and rally support for new browser APIs, to create a level playing field
           where a great user experience doesn't require a centralized system.
             </p>
           </div>


### PR DESCRIPTION
Application Programming Interfaces (APIs) are normally spelled in typical acronym fashion (so uppercase). I fixed this here to conform to that standard.

By the way, awesome stuff you guys. I'm really supporting this project. I'll be watching to see if there's anything else I can help with. Likewise, please feel free to reach out if there is any additional help necessary.